### PR TITLE
refactor spagcn graph construct; use dance data object in the example spagcn script

### DIFF
--- a/dance/data/base.py
+++ b/dance/data/base.py
@@ -37,7 +37,7 @@ class BaseData(ABC):
 
     FEATURE_CONFIGS: List[str] = ["feature_layer", "feature_channel", "channel_type"]
     LABEL_CONFIGS: List[str] = ["label_channel"]
-    DATA_CHANNELS: List[str] = ["obsm", "varm", "obsp", "varp"]
+    DATA_CHANNELS: List[str] = ["obsm", "varm", "obsp", "varp", "uns"]
 
     def __init__(self, data: Union[AnnData, MuData], train_size: Optional[int] = None, val_size: int = 0,
                  test_size: int = -1):

--- a/dance/datasets/spatial.py
+++ b/dance/datasets/spatial.py
@@ -81,7 +81,7 @@ class SpotDataset:
         self.data_id = data_id
         self.data_dir = data_dir + "/{}".format(data_id)
         self.data_url = dataset[data_id]
-        self.load_data()
+        self._load_data()
         self.adj = None
 
     def get_all_data(self):
@@ -115,7 +115,7 @@ class SpotDataset:
                 return False
         return True
 
-    def load_data(self):
+    def _load_data(self):
         if self.is_complete():
             pass
         else:
@@ -142,6 +142,14 @@ class SpotDataset:
         self.data.obs["label"] = list(map(lambda x: classes[x], label["ground_truth"].tolist()))
         self.data.obs["ground_truth"] = label["ground_truth"].tolist()
         return self
+
+    def load_data(self):
+        adata = self.data
+        spatial = adata.obs[["x", "y"]]
+        spatial_pixel = adata.obs[["x_pixel", "y_pixel"]]
+        image = self.img
+        label = adata.obs[["label"]]
+        return image, adata, spatial, spatial_pixel, label
 
 
 class CellTypeDeconvoDataset:

--- a/dance/modules/spatial/spatial_domain/spagcn.py
+++ b/dance/modules/spatial/spatial_domain/spagcn.py
@@ -605,7 +605,7 @@ class SpaGCN:
 
     def fit(
             self,
-            adata,
+            embed,
             adj,
             num_pcs=50,
             lr=0.005,
@@ -622,7 +622,7 @@ class SpaGCN:
 
         Parameters
         ----------
-        adata :
+        embed :
             input data.
         adj :
             adjacent matrix.
@@ -666,19 +666,10 @@ class SpaGCN:
         self.n_clusters = n_clusters
         self.res = res
         self.tol = tol
-        assert adata.shape[0] == adj.shape[0] == adj.shape[1]
-        pca = PCA(n_components=self.num_pcs)
-        if issparse(adata.X):
-            pca.fit(adata.X.A)
-            embed = pca.transform(adata.X.A)
-        else:
-            pca.fit(adata.X)
-            embed = pca.transform(adata.X)
-        ###------------------------------------------###
         if self.l is None:
             raise ValueError('l should be set before fitting the model!')
         adj_exp = np.exp(-1 * (adj**2) / (2 * (self.l**2)))
-        #----------Train model----------
+
         self.model = SimpleGCDEC(embed.shape[1], embed.shape[1])
         self.model.fit(embed, adj_exp, lr=self.lr, max_epochs=self.max_epochs, weight_decay=self.weight_decay,
                        opt=self.opt, init_spa=self.init_spa, init=self.init, n_neighbors=self.n_neighbors,

--- a/dance/transforms/graph/__init__.py
+++ b/dance/transforms/graph/__init__.py
@@ -1,6 +1,9 @@
 from dance.transforms.graph.cell_feature_graph import CellFeatureGraph, PCACellFeatureGraph
+from dance.transforms.graph.spatial_graph import SpaGCNGraph, SpaGCNGraph2D
 
 __all__ = [
     "CellFeatureGraph",
     "PCACellFeatureGraph",
+    "SpaGCNGraph",
+    "SpaGCNGraph2D",
 ]  # yapf: disable

--- a/dance/transforms/graph/spatial_graph.py
+++ b/dance/transforms/graph/spatial_graph.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from dance.transforms.base import BaseTransform
+from dance.typing import Sequence
+from dance.utils.matrix import pairwise_distance
+
+
+class SpaGCNGraph(BaseTransform):
+
+    def __init__(self, alpha, beta, *, channels: Sequence[str] = ("spatial", "spatial_pixel", "image"),
+                 channel_types: Sequence[str] = ("obsm", "obsm", "uns"), **kwargs):
+        """Initialize SpaGCNGraph.
+
+        Parameters
+        ----------
+        alpha
+            Controls the color scale.
+        beta
+            Controls the range of the neighborhood when calculating grey values for one spot.
+
+        """
+        super().__init__(**kwargs)
+
+        self.alpha = alpha
+        self.beta = beta
+        self.channels = channels
+        self.channel_types = channel_types
+
+    def __call__(self, data):
+        xy = data.get_feature(return_type="numpy", channel=self.channels[0], channel_type=self.channel_types[0])
+        xy_pixel = data.get_feature(return_type="numpy", channel=self.channels[1], channel_type=self.channel_types[1])
+        img = data.get_feature(return_type="numpy", channel=self.channels[2], channel_type=self.channel_types[2])
+        self.logger.info("Start calculating the adjacency matrix using the histology image")
+
+        g = np.zeros((xy.shape[0], 3))
+        beta_half = round(self.beta / 2)
+        x_lim, y_lim = img.shape[:2]
+        for i, (x_pixel, y_pixel) in enumerate(xy_pixel):
+            top = max(0, x_pixel - beta_half)
+            left = max(0, y_pixel - beta_half)
+            bottom = min(x_lim, x_pixel + beta_half + 1)
+            right = min(y_lim, y_pixel + beta_half + 1)
+            local_view = img[top:bottom, left:right]
+            g[i] = np.mean(local_view, axis=(0, 1))
+        g_var = g.var(0)
+        self.logger.info(f"Variances of c0, c1, c2 = {g_var}")
+
+        z = (g * g_var).sum(1, keepdims=True) / g_var.sum()
+        z = (z - z.mean()) / z.std()
+        z *= xy.std(0).max() * self.alpha
+
+        xyz = np.hstack((xy, z)).astype(np.float32)
+        self.logger.info(f"Varirances of x, y, z = {xyz.var(0)}")
+        data.data.obsp[self.out] = pairwise_distance(xyz, dist_func_id=0)
+
+        return data
+
+
+class SpaGCNGraph2D(BaseTransform):
+
+    def __init__(self, *, channel: str = "spatial_pixel", **kwargs):
+        super().__init__(**kwargs)
+
+        self.channel = channel
+
+    def __call__(self, data):
+        x = data.get_feature(channel=self.channel, channel_type="obsm", return_type="numpy")
+        data.data.obsp[self.out] = pairwise_distance(x.astype(np.float32), dist_func_id=0)
+        return data

--- a/dance/transforms/graph_construct.py
+++ b/dance/transforms/graph_construct.py
@@ -66,49 +66,6 @@ def extract_color(x_pixel=None, y_pixel=None, image=None, beta=49):
     return c3
 
 
-def calculate_adj_matrix(x, y, x_pixel=None, y_pixel=None, image=None, beta=49, alpha=1, histology=True):
-    # x,y,x_pixel, y_pixel are lists
-    if histology:
-        assert (x_pixel is not None) & (x_pixel is not None) & (image is not None)
-        assert (len(x) == len(x_pixel)) & (len(y) == len(y_pixel))
-        print("Calculateing adj matrix using histology image...")
-        # beta to control the range of neighbourhood when calculate grey vale for one spot
-        # alpha to control the color scale
-        beta_half = round(beta / 2)
-        g = []
-        for i in range(len(x_pixel)):
-            max_x = image.shape[0]
-            max_y = image.shape[1]
-            nbs = image[max(0, x_pixel[i] - beta_half):min(max_x, x_pixel[i] + beta_half + 1),
-                        max(0, y_pixel[i] - beta_half):min(max_y, y_pixel[i] + beta_half + 1)]
-            g.append(np.mean(np.mean(nbs, axis=0), axis=0))
-        c0, c1, c2 = [], [], []
-        for i in g:
-            c0.append(i[0])
-            c1.append(i[1])
-            c2.append(i[2])
-        c0 = np.array(c0)
-        c1 = np.array(c1)
-        c2 = np.array(c2)
-        print("Var of c0,c1,c2 = ", np.var(c0), np.var(c1), np.var(c2))
-        c3 = (c0 * np.var(c0) + c1 * np.var(c1) + c2 * np.var(c2)) / (np.var(c0) + np.var(c1) + np.var(c2))
-        c4 = (c3 - np.mean(c3)) / np.std(c3)
-        z_scale = np.max([np.std(x), np.std(y)]) * alpha
-        z = c4 * z_scale
-        z = z.tolist()
-        print("Var of x,y,z = ", np.var(x), np.var(y), np.var(z))
-        X = np.array([x, y, z]).T.astype(np.float32)
-    else:
-        print("Calculateing adj matrix using xy only...")
-        X = np.array([x, y]).T.astype(np.float32)
-    return pairwise_distance(X)
-
-
-def construct_graph(x, y, x_pixel=None, y_pixel=None, image=None, beta=49, alpha=1, histology=True):
-    return calculate_adj_matrix(x, y, x_pixel=x_pixel, y_pixel=y_pixel, image=image, beta=beta, alpha=alpha,
-                                histology=histology)
-
-
 def construct_enhanced_feature_graph(u, v, e, cell_node_features, enhance_graph=None, test=False, **kwargs):
     """Generate a feature-cell graph, enhanced with domain-knowledge (e.g. pathway).
 

--- a/dance/transforms/graph_construct.py
+++ b/dance/transforms/graph_construct.py
@@ -8,7 +8,6 @@ from typing import List, Union
 import anndata as ad
 import dgl
 import networkx as nx
-import numba
 import numpy as np
 import pandas as pd
 import scanpy as sc
@@ -26,24 +25,6 @@ from torch.nn import functional as F
 
 import dance.transforms.preprocess
 from dance import logger
-
-
-@numba.njit("f4(f4[:], f4[:])")
-def euclid_dist(t1, t2):
-    sum = 0
-    for i in range(t1.shape[0]):
-        sum += (t1[i] - t2[i])**2
-    return np.sqrt(sum)
-
-
-@numba.njit("f4[:,:](f4[:,:])", parallel=True, nogil=True)
-def pairwise_distance(X):
-    n = X.shape[0]
-    adj = np.empty((n, n), dtype=np.float32)
-    for i in numba.prange(n):
-        for j in numba.prange(n):
-            adj[i][j] = euclid_dist(X[i], X[j])
-    return adj
 
 
 def csr_cosine_similarity(input_csr_matrix):


### PR DESCRIPTION
Hi @JiayuanDing100, I have updated the SpaGCN example script with the following changes:

- Refactored spatial graph construct to `SpaGCNGraph` and `SpaGCNGraph2D` transformation objects
- Load raw data objects (`adata`, `spatial`, `spatial_pixel`, etc.) from the dataset object and construct the dance Data object.

Feel free to comment under this thread about any editing suggestions or questions. Otherwise, let me know if it is good to merge. Afterward, please help update `stagate`, `louvain`, and `stlearn` following the changes made in this PR.