### PR TITLE
updating test_data parameters

### DIFF
--- a/dance/datasets/singlemodality.py
+++ b/dance/datasets/singlemodality.py
@@ -316,21 +316,18 @@ class ImputationDatasetParams:
     random_seed = None
     min_counts = None
     train_dataset = None
-    test_dataset = None
     gpu = None
     filetype = None
 
 
 class ImputationDataset():
 
-    def __init__(self, random_seed=10, gpu=-1, filetype=None, data_dir="data", train_dataset="human_stemcell",
-                 test_dataset="pbmc", min_counts=1):
+    def __init__(self, random_seed=10, gpu=-1, filetype=None, data_dir="data", train_dataset="human_stemcell", min_counts=1):
         self.params = ImputationDatasetParams
         self.params.data_dir = data_dir
         self.params.random_seed = random_seed
         self.params.min_counts = min_counts
         self.params.train_dataset = train_dataset
-        self.params.test_dataset = test_dataset
         self.params.gpu = gpu
         self.params.filetype = filetype
 

--- a/examples/single_modality/imputation/deepimpute.py
+++ b/examples/single_modality/imputation/deepimpute.py
@@ -36,8 +36,6 @@ if __name__ == '__main__':
     parser.add_argument("--filetype", type=str, default='h5', choices=['csv', 'gz', 'h5'],
                         help='data file type, csv, csv.gz, or h5')
     parser.add_argument("--train_dataset", default='mouse_brain_data', type=str, help="dataset id")
-    parser.add_argument("--test_dataset", default='pbmc_data', type=str, help="dataset id")
-    parser.add_argument("--hiddem_dim", type=float, default=256, help="number of neurons in the dense layer")
     parser.add_argument("--minVMR", type=float, default=0.5, help="Minimum variance to mean ratio.")
     parser.add_argument("--ntop", type=int, default=5, help="Number of predictors.")
     parser.add_argument("--cell_subset", type=int, default=1, help="Cell subset.")
@@ -56,9 +54,8 @@ if __name__ == '__main__':
         gpu=params.gpu,
         # evaluate = params.evaluate,
         data_dir=params.data_dir,
-        train_dataset='pbmc_data',
-        test_dataset=params.test_dataset,
-        filetype='h5')
+        train_dataset=params.train_dataset,
+        filetype=params.filetype)
     dataloader.download_all_data()
     # dataloader.download_pretrained_data()
 


### PR DESCRIPTION
Values passed in the arguments were static, causing the algorithm to run every time on the same dataset. 
Updating default input argument in ImputationDataset class, previously initialized with train_dataset = 'pbmc_data' and filetype = 'h5'. Now changed to  train_dataset = params.train_dataset and filetype = params.filetype

Also removed test_dataset and hiddem_dim arguments from arg_parser