### PR TITLE
change python-igraph to igraph

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 h5py==3.9.0
+igraph==0.10.1
 leidenalg==0.10.0
 mudata==0.2.3
 networkx==3.1
@@ -8,7 +9,6 @@ opencv-python==4.8.0.74
 openpyxl==3.1.2
 pandas==2.0.3
 pyro-ppl==1.8.5
-python-igraph==0.10.1
 requests==2.31.0
 scanpy==1.9.3
 scikit-learn==1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ keywords =
 [options]
 install_requires =
     h5py
+    igraph
     leidenalg
     mudata
     networkx
@@ -41,7 +42,6 @@ install_requires =
     openpyxl
     pandas
     pyro-ppl
-    python-igraph
     requests
     scanpy
     scikit-learn


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for why this is necessary.

I would also recommend using the latest `igraph`. Currently it is pinned to 0.10.1, but note that `leidenalg` 0.10, which was adopted in this repo a few days ago, is already based on a newer igraph version.