### PR TITLE
expfeat: implement anndata transform adaptor

### DIFF
--- a/dance/transforms/base.py
+++ b/dance/transforms/base.py
@@ -60,7 +60,7 @@ class AnnDataAdaptor:
 
     """
 
-    def __init__(self, transform):
+    def __init__(self, transform, **data_init_kwargs):
         warnings.warn(
             "This is a temporary patch to enable transforming AnnData, and "
             "might have potential incompatibility issues. Use cautiously.",
@@ -68,8 +68,9 @@ class AnnDataAdaptor:
             stacklevel=2,
         )
         self.transform = transform
+        self.data_init_kwargs = data_init_kwargs
 
     def __call__(self, adata: AnnData) -> AnnData:
-        data = Data(adata)
+        data = Data(adata, **self.data_init_kwargs)
         self.transform(data)
         return data.data

--- a/dance/transforms/base.py
+++ b/dance/transforms/base.py
@@ -1,5 +1,8 @@
 import hashlib
+import warnings
 from abc import ABC, abstractmethod
+
+from anndata import AnnData
 
 from dance import logger
 from dance.data.base import Data
@@ -44,3 +47,29 @@ class BaseTransform(ABC):
     @abstractmethod
     def __call__(self, data: Data) -> Data:
         raise NotImplementedError
+
+
+class AnnDataAdaptor:
+    """Adaptor for transforming AnnData instead of dance data object.
+
+    Example
+    -------
+    Modify an :class:`AnnData` object inplace
+
+        >>> AnnDataAdaptor(FilterGenes(mode="sum"))(adata)
+
+    """
+
+    def __init__(self, transform):
+        warnings.warn(
+            "This is a temporary patch to enable transforming AnnData, and "
+            "might have potential incompatibility issues. Use cautiously.",
+            UserWarning,
+            stacklevel=2,
+        )
+        self.transform = transform
+
+    def __call__(self, adata: AnnData) -> AnnData:
+        data = Data(adata)
+        self.transform(data)
+        return data.data

--- a/dance/transforms/graph/cell_feature_graph.py
+++ b/dance/transforms/graph/cell_feature_graph.py
@@ -34,7 +34,7 @@ class CellFeatureGraph(BaseTransform):
         num_cells, num_feats = feat.shape
 
         row, col = np.nonzero(feat)
-        edata = np.array(feat[row, col])[:, None]
+        edata = np.array(feat[row, col]).ravel()[:, None]
         self.logger.info(f"Number of nonzero entries: {edata.size:,}")
         self.logger.info(f"Nonzero rate = {edata.size / num_cells / num_feats:.1%}")
 


### PR DESCRIPTION
An experimental feature that allows user to directly plugin dance transforms with a plain `AnnData` object, rather than requiring the wrapped dance data object.

In the future, it would be good to see if we can make this compatibility native within the transforms object.