### PR TITLE
fix: align `obs_names` of mod2 to mod1 when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## \[Unreleased\]
 
 ## Notes
 
 Format:
-- Title: [version] - YYYY-MM-DD
+
+- Title: \[version\] - YYYY-MM-DD
 - Subtitle: tags (see below)
 - Items: Description of the change with link to issue/pr if available
 
 Tags:
+
 - Added
 - Fixed
 - Changed

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -403,6 +403,10 @@ class ModalityMatchingDataset(MultiModalityDataset):
 
         train_mod1, train_mod2, train_label, test_mod1, test_mod2, test_label = raw_data
         modalities = [train_mod1, train_mod2, test_mod1, test_mod2]
+        if is_numeric(train_mod2.obs_names[0]):
+            train_mod2.obs_names=train_mod1.obs_names
+        if is_numeric(test_mod2.obs_names[0]):
+            test_mod2.obs_names=test_mod1.obs_names
 
         # TODO: support other two subtasks
         # assert self.subtask in ("openproblems_bmmc_cite_phase2_rna", "openproblems_bmmc_cite_phase2_rna_subset",

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -305,6 +305,18 @@ class ModalityPredictionDataset(MultiModalityDataset):
         return data
 
     def _maybe_preprocess(self, raw_data, selection_threshold=10000):
+        
+        changed_count = 0  # keep track to modified entries due to ensuring count data type
+        for i in range(4):
+            m_data = raw_data[i].X
+            int_data = m_data.astype(int)
+            changed_count += np.sum(int_data != m_data)
+            raw_data[i].X = int_data
+            raw_data[i].layers["counts"] = raw_data[i].X
+        if changed_count > 0:
+            logger.warning("Implicit modification: to ensure count (integer type) data, "
+                           f"a total number of {changed_count} entries were modified.")
+            
         if self.preprocess == "feature_selection":
             if raw_data[0].shape[1] > selection_threshold:
                 sc.pp.highly_variable_genes(raw_data[0], layer="counts", flavor="seurat_v3",

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -255,11 +255,9 @@ class ModalityPredictionDataset(MultiModalityDataset):
         "GSE127064_p0Brain_gex2atac":
         "https://www.dropbox.com/scl/fi/k4p3nkkqq56ev6ljyo5se/GSE127064_p0Brain_gex2atac.zip?rlkey=y7kayqmk2l72jjogzlvfxtl74&dl=1",
         "GSE117089_mouse_gex2atac":
-        "https://www.dropbox.com/scl/fi/egktuwiognr06xebeuouk/GSE117089_mouse_gex2atac.zip?rlkey=jadp3hlopc3112lmxe6nz5cd1&dl=1",
-        "GSE117089_A549_gex2atac":
-        "https://www.dropbox.com/scl/fi/b7evc2n5ih5o3xxwcd7uq/GSE117089_A549_gex2atac.zip?rlkey=b5o0ykptfodim59qwnu2m89fh&dl=1",
+        "https://www.dropbox.com/scl/fi/hbo5eel8vtkctwhgelu5u/GSE117089_mouse_gex2atac.zip?rlkey=84t4kj1ls7ut09dpcbj86mtlc&dl=1",
         "GSE117089_sciCAR_gex2atac":
-        "https://www.dropbox.com/scl/fi/juibpvmtv2otvfsq1xyr7/GSE117089_sciCAR_gex2atac.zip?rlkey=qcdbfqsuhab56bc553cwm78gc&dl=1",
+        "https://www.dropbox.com/scl/fi/hc0c48so824uohx0szs3h/GSE117089_sciCAR_gex2atac.zip?rlkey=4xjayirgijodd1fqcf7a42apo&dl=1",
         "GSE140203_3T3_HG19_atac2gex":
         "https://www.dropbox.com/scl/fi/v1vbypz87t1rz012vojkh/GSE140203_3T3_HG19_atac2gex.zip?rlkey=xmxrwso5e5ty3w53ctbm5bo9z&dl=1",
         "GSE140203_3T3_MM10_atac2gex":
@@ -345,9 +343,9 @@ class ModalityMatchingDataset(MultiModalityDataset):
         "10k_pbmc":
         "https://www.dropbox.com/scl/fi/1wi9u5zwzx7td9akk1cri/10k_pbmc.zip?rlkey=u9ir7b6d8s3t29sk2hu7v29au&dl=1",
         "GSE117089_mouse_gex2atac":
-        "https://www.dropbox.com/scl/fi/cq8cbidn486pvol6obcbq/GSE117089_mouse_gex2atac.zip?rlkey=k2axpyi8tdsvindwpqnzyik8x&dl=1",
+        "https://www.dropbox.com/scl/fi/dbxgretuwq1zekxibb2p0/GSE117089_mouse_gex2atac.zip?rlkey=wzqi309on9v1wllkiatnkpnhv&dl=1",
         "GSE117089_sciCAR_gex2atac":
-        "https://www.dropbox.com/scl/fi/riew8e0xkf2gxty296r86/GSE117089_sciCAR_gex2atac.zip?rlkey=0ye3s19adnj2nfbpv5qfu9w62&dl=1",
+        "https://www.dropbox.com/scl/fi/4sohkymkqyry5xkx34oiw/GSE117089_sciCAR_gex2atac.zip?rlkey=6exg6ybf5ufhagycj5g7hq5vi&dl=1",
         "GSE127064_AdBrain_gex2atac":
         "https://www.dropbox.com/scl/fi/mktue5y4bsf9w17t7jyq3/GSE127064_AdBrain_gex2atac.zip?rlkey=3qtazuova6v1rin630keryman&dl=1",
         "GSE127064_p0Brain_gex2atac":

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -16,6 +16,12 @@ from dance.transforms.preprocess import lsiTransformer
 from dance.typing import List
 from dance.utils.download import download_file, unzip_file
 
+def is_numeric(s):
+    try:
+        float(s)  
+        return True
+    except ValueError:
+        return False
 
 class MultiModalityDataset(BaseDataset, ABC):
 

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -404,9 +404,9 @@ class ModalityMatchingDataset(MultiModalityDataset):
         train_mod1, train_mod2, train_label, test_mod1, test_mod2, test_label = raw_data
         modalities = [train_mod1, train_mod2, test_mod1, test_mod2]
         if is_numeric(train_mod2.obs_names[0]):
-            train_mod2.obs_names=train_mod1.obs_names
+            train_mod2.obs_names = train_mod1.obs_names
         if is_numeric(test_mod2.obs_names[0]):
-            test_mod2.obs_names=test_mod1.obs_names
+            test_mod2.obs_names = test_mod1.obs_names
 
         # TODO: support other two subtasks
         # assert self.subtask in ("openproblems_bmmc_cite_phase2_rna", "openproblems_bmmc_cite_phase2_rna_subset",

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -16,12 +16,14 @@ from dance.transforms.preprocess import lsiTransformer
 from dance.typing import List
 from dance.utils.download import download_file, unzip_file
 
+
 def is_numeric(s):
     try:
-        float(s)  
+        float(s)
         return True
     except ValueError:
         return False
+
 
 class MultiModalityDataset(BaseDataset, ABC):
 

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -14,15 +14,8 @@ from dance.data import Data
 from dance.datasets.base import BaseDataset
 from dance.transforms.preprocess import lsiTransformer
 from dance.typing import List
+from dance.utils import is_numeric
 from dance.utils.download import download_file, unzip_file
-
-
-def is_numeric(s):
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
 
 
 class MultiModalityDataset(BaseDataset, ABC):

--- a/dance/datasets/multimodality.py
+++ b/dance/datasets/multimodality.py
@@ -305,7 +305,7 @@ class ModalityPredictionDataset(MultiModalityDataset):
         return data
 
     def _maybe_preprocess(self, raw_data, selection_threshold=10000):
-        
+
         changed_count = 0  # keep track to modified entries due to ensuring count data type
         for i in range(4):
             m_data = raw_data[i].X
@@ -316,7 +316,7 @@ class ModalityPredictionDataset(MultiModalityDataset):
         if changed_count > 0:
             logger.warning("Implicit modification: to ensure count (integer type) data, "
                            f"a total number of {changed_count} entries were modified.")
-            
+
         if self.preprocess == "feature_selection":
             if raw_data[0].shape[1] > selection_threshold:
                 sc.pp.highly_variable_genes(raw_data[0], layer="counts", flavor="seurat_v3",

--- a/dance/modules/multi_modality/predict_modality/cmae.py
+++ b/dance/modules/multi_modality/predict_modality/cmae.py
@@ -169,7 +169,7 @@ class VAEGen(nn.Module):
 
     def encode(self, images):
         hiddens = self.enc(images)
-        noise = Variable(torch.randn(hiddens.size()).cuda(hiddens.data.get_device()))
+        noise = torch.randn_like(hiddens)
         return hiddens, noise
 
     def decode(self, hiddens):

--- a/dance/utils/__init__.py
+++ b/dance/utils/__init__.py
@@ -20,6 +20,14 @@ def hexdigest(x: str, /) -> str:
     return hashlib.md5(x.encode()).hexdigest()
 
 
+def is_numeric(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
 class SimpleIndexDataset(Dataset):
 
     def __init__(self, dataset):

--- a/examples/multi_modality/predict_modality/babel.py
+++ b/examples/multi_modality/predict_modality/babel.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # Obtain training and testing data
     x_train, y_train = data.get_train_data(return_type="torch")
     x_test, y_test = data.get_test_data(return_type="torch")
-    x_train, y_train,x_test, y_test = x_train.float(), y_train.float(),x_test.float(), y_test.float()
+    x_train, y_train, x_test, y_test = x_train.float(), y_train.float(), x_test.float(), y_test.float()
     # Train and evaluate the model
     res = pd.DataFrame({'rmse': [], 'seed': [], 'subtask': [], 'method': []})
     for k in range(args.runs):

--- a/examples/multi_modality/predict_modality/babel.py
+++ b/examples/multi_modality/predict_modality/babel.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     # Obtain training and testing data
     x_train, y_train = data.get_train_data(return_type="torch")
     x_test, y_test = data.get_test_data(return_type="torch")
-
+    x_train, y_train,x_test, y_test = x_train.float(), y_train.float(),x_test.float(), y_test.float()
     # Train and evaluate the model
     res = pd.DataFrame({'rmse': [], 'seed': [], 'subtask': [], 'method': []})
     for k in range(args.runs):

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -55,7 +55,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "spatial_domain-louvain-151507": "--sample_number 151507 --seed 10",
     "spatial_domain-spagcn-151507": "--sample_number 151507 --lr 0.009",
     "spatial_domain-stagate-151507": "--sample_number 151507 --seed 2021",
-    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 0",
+    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 1",
 }  # yapf: disable
 
 full_options_dict: Dict[str, Tuple[str, str]] = {

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -55,7 +55,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "spatial_domain-louvain-151507": "--sample_number 151507 --seed 10",
     "spatial_domain-spagcn-151507": "--sample_number 151507 --lr 0.009",
     "spatial_domain-stagate-151507": "--sample_number 151507 --seed 2021",
-    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 3",
+    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 6",
 }  # yapf: disable
 
 full_options_dict: Dict[str, Tuple[str, str]] = {

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -55,7 +55,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "spatial_domain-louvain-151507": "--sample_number 151507 --seed 10",
     "spatial_domain-spagcn-151507": "--sample_number 151507 --lr 0.009",
     "spatial_domain-stagate-151507": "--sample_number 151507 --seed 2021",
-    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 2",
+    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 3",
 }  # yapf: disable
 
 full_options_dict: Dict[str, Tuple[str, str]] = {

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -55,7 +55,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "spatial_domain-louvain-151507": "--sample_number 151507 --seed 10",
     "spatial_domain-spagcn-151507": "--sample_number 151507 --lr 0.009",
     "spatial_domain-stagate-151507": "--sample_number 151507 --seed 2021",
-    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 1",
+    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 2",
 }  # yapf: disable
 
 full_options_dict: Dict[str, Tuple[str, str]] = {

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -42,7 +42,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "joint_embedding-scmvae-gex_adt": "--subtask openproblems_bmmc_cite_phase2 --device cuda --max_epoch 2 --anneal_epoch 2 --epoch_per_test 2 --max_iteration 3",
     "match_modality-cmae-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --max_epochs 2",
     "match_modality-scmm-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --epochs 2",
-    "match_modality-scmogcn-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --threshold_quantile 0.85 --device cuda --epochs 100",
+    "match_modality-scmogcn-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --threshold_quantile 0.85 --device cuda --epochs 2",
     "predict_modality-babel-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --max_epochs 2 --earlystop 2",
     "predict_modality-cmae-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --max_epochs 2",
     "predict_modality-scmm-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --epochs 2",

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -42,7 +42,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "joint_embedding-scmvae-gex_adt": "--subtask openproblems_bmmc_cite_phase2 --device cuda --max_epoch 2 --anneal_epoch 2 --epoch_per_test 2 --max_iteration 3",
     "match_modality-cmae-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --max_epochs 2",
     "match_modality-scmm-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --epochs 2",
-    "match_modality-scmogcn-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --threshold_quantile 0.85 --device cuda --epochs 2",
+    "match_modality-scmogcn-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --threshold_quantile 0.85 --device cuda --epochs 100",
     "predict_modality-babel-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --max_epochs 2 --earlystop 2",
     "predict_modality-cmae-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --max_epochs 2",
     "predict_modality-scmm-gex2adt_subset": "--subtask openproblems_bmmc_cite_phase2_rna_subset --device cuda --epochs 2",

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -55,7 +55,7 @@ light_options_dict: Dict[str, Tuple[str, str]] = {
     "spatial_domain-louvain-151507": "--sample_number 151507 --seed 10",
     "spatial_domain-spagcn-151507": "--sample_number 151507 --lr 0.009",
     "spatial_domain-stagate-151507": "--sample_number 151507 --seed 2021",
-    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 6",
+    "spatial_domain-stlearn-151507": "--n_clusters 20 --sample_number 151507 --seed 0",
 }  # yapf: disable
 
 full_options_dict: Dict[str, Tuple[str, str]] = {


### PR DESCRIPTION
Modified the test epochs of match modality-scmognn-gex2adt_subset to prevent minimum_weight_full_matching from reporting an error cost matrix is ​​infeasible. In addition, the obs_names of mod2 that are numbers in match_modality are aligned with the obs_names of mod1. However, it should be noted that these are all in Modified locally, I will test it again when my vscode can be directly connected to github.
I have tested it in new server.
Update datasets with appropriate batch labels.
Currently I am still copying and pasting updates, I will try to connect directly soon.