### PR TITLE
feat: pipeline resolve

### DIFF
--- a/dance/pipeline.py
+++ b/dance/pipeline.py
@@ -194,6 +194,14 @@ class Pipeline(Action):
     @property
     def functional(self) -> Callable:
 
+        # Try to resolve all functionals first before returning the composed funcitonal
+        try:
+            for a in self._pipeline:
+                a.functional
+        except KeyError as e:
+            raise KeyError(f"Failed to resolve for {a}:\n   scope={a.scope}\n   type={a.type}"
+                           f"\n   parent_type={a.parent_type}\n   full_type={a.full_type}") from e
+
         # TODO: maybe come up with some mechanism to automatically figure out
         # what the input (and output) should be?
         def bounded_functional(*args, **kwargs):

--- a/dance/pipeline.py
+++ b/dance/pipeline.py
@@ -139,15 +139,15 @@ class Pipeline(Action):
 
     @property
     def config(self) -> Config:
-        self._config
+        return self._config
 
     @property
     def config_dict(self) -> Dict[str, Any]:
-        self.config.to_dict()
+        return self.config.to_dict()
 
     @property
     def config_yaml(self) -> str:
-        self.config.to_yaml()
+        return self.config.to_yaml()
 
     def __iter__(self):
         yield from self._pipeline

--- a/dance/pipeline.py
+++ b/dance/pipeline.py
@@ -24,32 +24,52 @@ class Action:
         type_: Optional[str] = None,
         desc: Optional[str] = None,
         target: Optional[str] = None,
-        scope: str = REGISTRY_PREFIX,
+        scope: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
+        _parent_type: Optional[str] = None,
         _registry: Registry = REGISTRY,
     ):
         self._type = type_
+        self._parent_type = _parent_type
         self._desc = desc  # TODO: extract default description from docstring?
         self._target = target
-        self._scope = scope
+        self.scope = scope
         self._params = default(params, {})
         self._registry = _registry  # for testing purposes
 
     @property
-    def type(self) -> str:
+    def type(self) -> Optional[str]:
         return self._type
+
+    @property
+    def parent_type(self) -> Optional[str]:
+        return self._parent_type
+
+    @property
+    def full_type(self) -> Optional[str]:
+        if self.type is None and self.parent_type is None:
+            return None
+        else:
+            return ".".join(filter(None, (self.parent_type, self.type)))
 
     @property
     def desc(self) -> Optional[str]:
         return self._desc
 
     @property
-    def target(self) -> str:
+    def target(self) -> Optional[str]:
         return self._target
 
     @property
     def scope(self) -> str:
         return self._scope
+
+    @scope.setter
+    def scope(self, val: Optional[str]):
+        val = default(val, REGISTRY_PREFIX)
+        if val == REGISTRY_PREFIX:
+            val = ".".join(filter(None, (val, self.parent_type, self.type)))
+        self._scope = val
 
     @property
     def params(self) -> Dict[str, Any]:
@@ -87,13 +107,14 @@ class Action:
         return deepcopy(self)
 
     @classmethod
-    def from_config(cls, cfg: ConfigLike):
+    def from_config(cls, cfg: ConfigLike, **kwargs):
         return cls(
             type_=cfg.get(cls.TYPE_KEY),
             desc=cfg.get(cls.DESC_KEY),
             target=cfg.get(cls.TARGET_KEY),
             scope=cfg.get(cls.SCOPE_KEY),
             params=cfg.get(cls.PARAMS_KEY),
+            **kwargs,
         )
 
     def to_config(self) -> Config:
@@ -121,7 +142,13 @@ class Action:
 class Pipeline(Action):
 
     # TODO: shared configs that are parsed under sub config dicts
-    def __init__(self, cfg: ConfigLike):
+    def __init__(self, cfg: ConfigLike, *, _parent_type: Optional[str] = None, _registry: Registry = REGISTRY):
+        super().__init__(
+            type_=cfg.get(self.TYPE_KEY),
+            desc=cfg.get(self.DESC_KEY),
+            _parent_type=_parent_type,
+            _registry=_registry,
+        )
         self._config = Config(cfg)
 
         self._pipeline: List[Action] = []
@@ -133,9 +160,7 @@ class Pipeline(Action):
                 raise KeyError(f"Cannot specify both {self.PARAMS_KEY!r} and {self.PIPELINE_KEY!r} at the same time.")
 
             cls = Pipeline if self.PIPELINE_KEY in sub_cfg else Action
-            self._pipeline.append(cls.from_config(sub_cfg))
-
-        super().__init__(type_=cfg.get(self.TYPE_KEY), desc=cfg.get(self.DESC_KEY))
+            self._pipeline.append(cls.from_config(sub_cfg, _parent_type=self.full_type, _registry=_registry))
 
     @property
     def config(self) -> Config:
@@ -178,8 +203,8 @@ class Pipeline(Action):
         return bounded_functional
 
     @classmethod
-    def from_config(cls, cfg: ConfigLike):
-        return cls(cfg)
+    def from_config(cls, cfg: ConfigLike, **kwargs):
+        return cls(cfg, **kwargs)
 
     @classmethod
     def from_config_file(cls, path: PathLike, **kwargs):

--- a/dance/settings.py
+++ b/dance/settings.py
@@ -1,5 +1,6 @@
 import logging
 import logging.config
+import os
 from pathlib import Path
 from typing import Union
 
@@ -20,7 +21,7 @@ _logger_config = {
     "loggers": {
         "dance": {
             "handlers": ["stream_handler"],
-            "level": "INFO",
+            "level": os.environ.get("DANCE_LOG_LEVEL", "INFO"),
             "propagate": False,
         },
     },

--- a/examples/config/cta_svm/preprocessing_config.yaml
+++ b/examples/config/cta_svm/preprocessing_config.yaml
@@ -1,19 +1,33 @@
 type: preprocessor
-desc: Preprocess scRNAseq counts for SVM by taking the weighted gene PCA components.
+desc: >-
+  Preprocess scRNA-seq counts into dense features for SVM by taking the
+  weighted sum of the gene PCA components.
 pipeline:
-  - type: cell_feature
+  - type: feature.cell
     target: WeightedFeaturePCA
-    # TODO: set to _registry_, which would be effectively the same as
-    # _registry_.preprocessor.cell_feature, which is resolved automatically
-    scope: dance.transforms.cell_feature
+    # Scope will be set to _registry_ by default, so you can leave out the
+    # specification of scope as well.
+    # Setting scope to "_registry_" will trigger auto-scope-resolve and
+    # iteratively combines the type. In this case, it will be resolved to
+    # "_registry_.preprocessor.feature.cell".
+    # You can also specify the absolute scope of the target object, rather than
+    # the scope of the registry. For example, the absolute scope for
+    # "WeightedFeaturePCA" is "dance.transforms.feature.cell".
+    scope: _registry_
     params:
       n_components: 400
       split_name: train
   - type: misc
     target: SetConfig
-    # TODO: set to _registry_, which would be effectively the same as
-    # _registry_.preprocessor.misc, which is resolved automatically
-    scope: dance.transforms.misc
+    # Scope will be set to _registry_ by default, so you can leave out the
+    # specification of scope as well.
+    # Setting scope to "_registry_" will trigger auto-scope-resolve and
+    # iteratively combines the type. In this case, it will be resolved to
+    # "_registry_.preprocessor.misc".
+    # You can also specify the absolute scope of the target object, rather than
+    # the scope of the registry. For example, the absolute scope for
+    # "SetConfig" is "dance.transforms.misc".
+    scope: _registry_
     params:
       config_dict:
         feature_channel: WeightedFeaturePCA

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dance.pipeline import Action, Pipeline
 from dance.registry import Registry
 
@@ -49,3 +51,79 @@ def test_pipeline(subtests):
         })
         assert repr(p) == ("Pipeline(\n    Action(BaseTransform)\n"
                            "    Pipeline(\n        Action(BaseTransform)\n    )\n)")
+
+
+def test_pipeline_scope_resolve(subtests):
+    r = Registry()
+    r.set("a.b.integer", int)
+
+    def pass_subtest(pipeline):
+        assert repr(pipeline) == "Pipeline(\n    Action(integer)\n)"
+        pipeline.functional  # test resolability
+
+    with subtests.test("_registry_.xxx.xxx"):
+        p = Pipeline({"pipeline": [{"target": "integer", "scope": "_registry_.a.b"}]}, _registry=r)
+        assert repr(p) == "Pipeline(\n    Action(integer)\n)"
+
+    with subtests.test("_registry_"):
+        # Full scope in parent pipeline
+        cfg = {
+            "type": "a.b",
+            "pipeline": [
+                {
+                    "target": "integer",
+                    "scope": "_registry_",
+                },
+            ],
+        }
+        pass_subtest(Pipeline(cfg, _registry=r))
+
+        # Full scope in the child pipeline
+        cfg = {
+            "pipeline": [
+                {
+                    "type": "a.b",
+                    "target": "integer",
+                    "scope": "_registry_",
+                },
+            ],
+        }
+        pass_subtest(Pipeline(cfg, _registry=r))
+
+        # Full scope constructed from parent and the child
+        cfg = {
+            "type": "a",
+            "pipeline": [
+                {
+                    "type": "b",
+                    "target": "integer",
+                    "scope": "_registry_",
+                },
+            ],
+        }
+        pass_subtest(Pipeline(cfg, _registry=r))
+
+        # Default scope is _registry_
+        cfg = {
+            "type": "a",
+            "pipeline": [
+                {
+                    "type": "b",
+                    "target": "integer",
+                },
+            ],
+        }
+        pass_subtest(Pipeline(cfg, _registry=r))
+
+        with pytest.raises(KeyError):
+            # Invalid scope a.c
+            cfg = {
+                "type": "a",
+                "pipeline": [
+                    {
+                        "type": "c",
+                        "target": "integer",
+                    },
+                ],
+            }
+            pass_subtest(Pipeline(cfg, _registry=r))


### PR DESCRIPTION
Automatically resolve pipeline registry scope.

Example:

```yaml
type: preprocessor
pipeline:
  - type: feature.cell
    target: WeightedGenePCA
    scope: _registry_  # this will be set by default
```

is the same as

```yaml
pipeline:
  - target: WeightedGenePCA
    scope: _registry_.preprocessor.feature.cell
```