### PR TITLE
Fix a bug in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ conda create -n ${envname} python=3.11 -y
 conda activate ${envname}
 
 # Install CUDA enabled dependencies
-pip install torch==${PYTORCH_VERSION} torchvision=${TORCHVISION_VERSION} ${PYTORCH_CHANNEL}
+pip install torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} ${PYTORCH_CHANNEL}
 pip install torch_geometric==${PYG_VERSION}
 pip install dgl==${DGL_VERSION} ${DGL_CHANNEL}
 


### PR DESCRIPTION
I notice that when using install.sh to install the packages, an error will be throwed:

ERROR: Invalid requirement: 'torchvision=0.16.1'
Hint: = is not a valid operator. Did you mean == ?

I fix the bug in the install.sh and now it works well. 